### PR TITLE
V1-4978 Enable CORS for main domain, enable PATCH method

### DIFF
--- a/charts/delphai-keda/Chart.yaml
+++ b/charts/delphai-keda/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: delphai-keda
 description: delphai service
 type: application
-version: 0.1.53
+version: 0.1.54
 appVersion: "1.16.0"

--- a/charts/delphai-keda/templates/ingress.yml
+++ b/charts/delphai-keda/templates/ingress.yml
@@ -17,6 +17,14 @@ spec:
   timeout_ms: 60000
   idle_timeout_ms: 500000
   connect_timeout_ms: 2000
+  {{ if or (eq .Values.subdomain "api") (eq .Values.subdomain "ml") }}
+  cors:
+    origins: "*"
+    methods: "GET, PUT, POST, DELETE, HEAD, OPTIONS, PATCH"
+    headers: "Origin, Content-Type, Accept, Authorization, X-Request-With, X-GENERAL-TOKEN, x-grpc-web,grpc-timeout"
+    credentials: true
+    max_age: "86400"
+  {{ end }}
 ---
 {{ if and (ne .Values.subdomain "api") (ne .Values.subdomain "ml") }}
 apiVersion: getambassador.io/v2
@@ -68,8 +76,8 @@ spec:
   idle_timeout_ms: 500000
   connect_timeout_ms: 2000
   cors:
-    origins: '*'
-    methods: "GET, PUT, POST, DELETE, HEAD, OPTIONS"
+    origins: "*"
+    methods: "GET, PUT, POST, DELETE, HEAD, OPTIONS, PATCH"
     headers: "Origin, Content-Type, Accept, Authorization, X-Request-With, X-GENERAL-TOKEN, x-grpc-web,grpc-timeout"
     credentials: true
     max_age: "86400"
@@ -89,8 +97,8 @@ spec:
   idle_timeout_ms: 500000
   connect_timeout_ms: 2000
   cors:
-    origins: '*'
-    methods: "GET, PUT, POST, DELETE, HEAD, OPTIONS"
+    origins: "*"
+    methods: "GET, PUT, POST, DELETE, HEAD, OPTIONS, PATCH"
     headers: "Origin, Content-Type, Accept, Authorization, X-Request-With, X-GENERAL-TOKEN, x-grpc-web,grpc-timeout"
     credentials: true
     max_age: "86400"
@@ -108,8 +116,8 @@ spec:
   rewrite: /grpc.reflection.v1alpha.ServerReflection/
   service: '{{ $.Release.Name }}-grpc:80'
   cors:
-    origins: '*'
-    methods: "GET, PUT, POST, DELETE, HEAD, OPTIONS"
+    origins: "*"
+    methods: "GET, PUT, POST, DELETE, HEAD, OPTIONS, PATCH"
     headers: "Origin, Content-Type, Accept, Authorization, X-Request-With, X-GENERAL-TOKEN, x-grpc-web,grpc-timeout"
     credentials: true
     max_age: "86400"
@@ -126,8 +134,8 @@ spec:
   rewrite: /grpc.health.v1.Health/
   service: '{{ $.Release.Name }}-grpc:80'
   cors:
-    origins: '*'
-    methods: "GET, PUT, POST, DELETE, HEAD, OPTIONS"
+    origins: "*"
+    methods: "GET, PUT, POST, DELETE, HEAD, OPTIONS, PATCH"
     headers: "Origin, Content-Type, Accept, Authorization, X-Request-With, X-GENERAL-TOKEN, x-grpc-web,grpc-timeout"
     credentials: true
     max_age: "86400"

--- a/charts/delphai-streaming/Chart.yaml
+++ b/charts/delphai-streaming/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: delphai-streaming
 description: delphai streaming with faust
 type: application
-version: 0.1.27
+version: 0.1.28
 appVersion: "1.16.0"


### PR DESCRIPTION
`Notifications` service is deployed now onto `review`/`pink` with this chart:
```
$ kubectl describe mapping notifications 
Name:         notifications
Namespace:    notifications
Kind:         Mapping
Spec:
  Host:             api.delphai.pink
  Prefix:           /notifications/
  Service:          notifications:8000
  Cors:
    Credentials:    true
    Headers:        Origin, Content-Type, Accept, Authorization, X-Request-With, X-GENERAL-TOKEN, x-grpc-web,grpc-timeout
    max_age:        86400
    Methods:        GET, PUT, POST, DELETE, HEAD, OPTIONS, PATCH
    Origins:        https://app.delphai.pink
```

It works in Firefox, Chrome, Safari. Hope we accessing these endpoints only from `app.delphai.*`