### PR TITLE
DEVOPS-27 Require Keycloak roles for OAuth

### DIFF
--- a/charts/delphai-keda/Chart.yaml
+++ b/charts/delphai-keda/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: delphai-keda
 description: delphai service
 type: application
-version: 0.1.56
+version: 0.2.0

--- a/charts/delphai-keda/templates/deployment.yml
+++ b/charts/delphai-keda/templates/deployment.yml
@@ -17,8 +17,8 @@ spec:
       labels:
         app: {{ .Release.Name }}
       annotations:
-        'prometheus.io/port': '9191'
-        'prometheus.io/scrape': 'true'
+        "prometheus.io/port": "9191"
+        "prometheus.io/scrape": "true"
     spec:
       tolerations:
         - key: "kubernetes.azure.com/scalesetpriority"
@@ -74,13 +74,19 @@ spec:
         - name: oauth2-proxy
           image: "quay.io/oauth2-proxy/oauth2-proxy:v7.2.0"
           args:
-            - '--email-domain=*'
+            - "--email-domain=*"
+            {{- range $role := .Values.http.oAuthRequireOneOfRoles }}
+            - "--allowed-role={{ $role }}"
+            {{- end }}
           env:
           - name: OAUTH2_PROXY_HTTP_ADDRESS
             value: 0.0.0.0:{{ .Values.http.oAuthProxyPort }}
 
           - name: OAUTH2_PROXY_PROVIDER
-            value: "oidc"
+            value: "keycloak-oidc"
+
+          - name: OAUTH2_PROXY_PROVIDER_DISPLAY_NAME
+            value: "Keycloak"
 
           - name: OAUTH2_PROXY_OIDC_ISSUER_URL
             valueFrom:

--- a/charts/delphai-keda/values.yaml
+++ b/charts/delphai-keda/values.yaml
@@ -18,6 +18,7 @@ http:
   public: true
   publicWithOAuth: false
   oAuthProxyPort: 37070
+  oAuthRequireOneOfRoles: []
 grpc:
   enabled: true
   port: 8080


### PR DESCRIPTION
Now applied on https://ml-tools.delphai.pink/ , works as expected