### PR TITLE
Add conditional annotation name of the ingress controller's service

### DIFF
--- a/charts/delphai-keda/templates/ingress.yml
+++ b/charts/delphai-keda/templates/ingress.yml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-http
   namespace: {{ .Release.Namespace }}
   annotations:
+    {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
+    external-dns.ambassador-service: emissary/emissary-ingress
+    {{- else -}}
     external-dns.ambassador-service: ambassador/ambassador
+    {{- end }}
 spec:
   hostname: '{{ .Values.subdomain }}.{{ .Values.domain }}'
   acmeProvider:


### PR DESCRIPTION
Kubernetes clusters with version greater or equal 1.22 cannot use ambassador helm chart because of several APIs depreciation, therefore emissary-ingress is used
But current version of the `delphai-keda` helm chart annotates host resources with `external-dns.ambassador-service: ambassador/ambassador` which is not recognized by `external-dns` (because it’s looking for `ambassador/ambassador` but there is `emissary/emissary-ingress`) thus Cloudflare DNS records are not updated
This patch uses condition based on the Kubernetes version 