### PR TITLE
Devops 121 optimize deployment speed images sizes

### DIFF
--- a/charts/delphai-keda/Chart.yaml
+++ b/charts/delphai-keda/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: delphai-keda
 description: delphai service
 type: application
-version: 0.2.3
+version: 0.2.4

--- a/charts/delphai-keda/templates/deployment.yml
+++ b/charts/delphai-keda/templates/deployment.yml
@@ -35,6 +35,18 @@ spec:
       nodeSelector:
         node_type: "gpu"
       {{ end }}
+      affinity:
+        {{ if .Values.podAntiAffinity }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - {{ .Release.Name }}
+            topologyKey: "kubernetes.io/hostname"
+        {{ end }}
       imagePullSecrets:
         - name: acr-credentials
       automountServiceAccountToken: true

--- a/charts/delphai-keda/values.yaml
+++ b/charts/delphai-keda/values.yaml
@@ -29,3 +29,4 @@ env: []
 gpu: false
 mountPath: /app/data
 fileShares: []
+podAntiAffinity: false


### PR DESCRIPTION
Adding pod anti-affinity so that if `podAntiAffinity` is set to `true` pods of the same application won't be scheduled on the same node.