### PR TITLE
Change prometheus server address

### DIFF
--- a/charts/delphai-keda/templates/scaled-object.yml
+++ b/charts/delphai-keda/templates/scaled-object.yml
@@ -14,7 +14,7 @@ spec:
   triggers:
   - type: prometheus
     metadata:
-      serverAddress: http://loki-prometheus-server.monitoring
+      serverAddress: http://prometheus-operated.monitoring
       metricName: delphai_requests_per_sec
       threshold: '{{ .Values.autoscaling.threshold }}'
       query: sum(rate(delphai_request_count_total{app="{{ .Release.Name }}"}[2m]))


### PR DESCRIPTION
Loki stack is not used anymore (in terms off stack), only its separate components.
That’s why auto scaling dependent on loki's Prometheus address is broken and needs to be fixed.