### PR TITLE
DEVOPS-193 DEVOPS-194 Prefix route

### DIFF
--- a/charts/delphai-keda/Chart.yaml
+++ b/charts/delphai-keda/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: delphai-keda
 description: delphai service
 type: application
-version: 0.2.11
+version: 0.2.12

--- a/charts/delphai-keda/templates/ingress.yml
+++ b/charts/delphai-keda/templates/ingress.yml
@@ -11,14 +11,10 @@
 apiVersion: getambassador.io/v2
 kind: Host
 metadata:
-  name: {{ $.Release.Name }}-domain{{ $domain_index }}-http
+  name: {{ $.Release.Name }}-domain{{ $domain_index }}-http-subdomain
   namespace: {{ $.Release.Namespace }}
   annotations:
-    {{ if (lookup "v1" "Service" "emissary" "emissary-ingress") }}
     external-dns.ambassador-service: emissary/emissary-ingress
-    {{ else if (lookup "v1" "Service" "ambassador" "ambassador") }}
-    external-dns.ambassador-service: ambassador/ambassador
-    {{ end }}
 spec:
   hostname: "{{ $.Values.subdomain }}.{{ $domain }}"
   acmeProvider:
@@ -31,13 +27,13 @@ spec:
 apiVersion: getambassador.io/v2
 kind: Mapping
 metadata:
-  name: {{ $.Release.Name }}-domain{{ $domain_index }}-http
+  name: {{ $.Release.Name }}-domain{{ $domain_index }}-http-subdomain
   namespace: {{ $.Release.Namespace }}
 spec:
-  {{ if and (ne $.Values.subdomain "api") (ne $.Values.subdomain "ml") }}
-  prefix: "/"
-  {{ else }}
+  {{ if or (eq $.Values.subdomain "api") (eq $.Values.subdomain "ml") }}
   prefix: "/{{ $.Release.Name }}/"
+  {{ else }}
+  prefix: "/"
   {{ end }}
   service: "{{ $.Release.Name }}:{{ if $.Values.http.publicWithOAuth }}{{ $.Values.http.oAuthProxyPort }}{{ else }}{{ $.Values.http.port }}{{ end }}"
   host: "{{ $.Values.subdomain }}.{{ $domain }}"

--- a/charts/delphai-keda/templates/ingress.yml
+++ b/charts/delphai-keda/templates/ingress.yml
@@ -49,6 +49,29 @@ spec:
     credentials: true
     max_age: "86400"
   {{ end }}
+
+{{ if eq $.Values.subdomain "api" }}
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: {{ $.Release.Name }}-domain{{ $domain_index }}-http-prefix
+  namespace: {{ $.Release.Namespace }}
+spec:
+  prefix: "/service/{{ $.Release.Name }}/"
+  service: "{{ $.Release.Name }}:{{ if $.Values.http.publicWithOAuth }}{{ $.Values.http.oAuthProxyPort }}{{ else }}{{ $.Values.http.port }}{{ end }}"
+{{ if eq $.Values.delphaiEnvironment "review" }}
+  host: "^app.*\\.{{ $domain }}$"
+  host_regex: true
+{{ else }}
+  host: "app.{{ $domain }}"
+{{ end }}
+  allow_upgrade:
+    - websocket
+  timeout_ms: 60000
+  idle_timeout_ms: 500000
+  connect_timeout_ms: 2000
+{{ end }} {{/* if eq $.Values.subdomain "api" */}}
 {{ end }} {{/* if and $.Values.http.enabled $.Values.http.public */}}
 
 {{ if and $.Values.grpc.enabled $.Values.grpc.public }}

--- a/charts/delphai-keda/templates/ingress.yml
+++ b/charts/delphai-keda/templates/ingress.yml
@@ -3,26 +3,25 @@
   {{ $domains = uniq (concat $domains (list "delphai.live" "delphai.com")) }}
 {{ end }}
 
-{{ range $domain_index, $domain := $domains }}
-
-{{ if and $.Values.http.enabled $.Values.http.public }}
-{{ if not (lookup "v1" "Service" "ambassador" "ambassador") }}
+{{ if or (and $.Values.http.enabled $.Values.http.public) (and $.Values.grpc.enabled $.Values.grpc.public) }}
 ---
 apiVersion: getambassador.io/v2
 kind: Host
 metadata:
-  name: {{ $.Release.Name }}-domain{{ $domain_index }}-http-subdomain
+  name: {{ $.Release.Name }}
   namespace: {{ $.Release.Namespace }}
-  annotations:
-    external-dns.ambassador-service: emissary/emissary-ingress
 spec:
-  hostname: "{{ $.Values.subdomain }}.{{ $domain }}"
+  hostname: "*"
   acmeProvider:
     authority: none
   requestPolicy:
     insecure:
       action: Route
-{{ end }} {{/* if not (lookup "v1" "Service" "ambassador" "ambassador") */}}
+{{ end }} {{/* if or (and $.Values.http.enabled $.Values.http.public) (and $.Values.grpc.enabled $.Values.grpc.public) */}}
+
+{{ range $domain_index, $domain := $domains }}
+
+{{ if and $.Values.http.enabled $.Values.http.public }}
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -53,22 +52,6 @@ spec:
 {{ end }} {{/* if and $.Values.http.enabled $.Values.http.public */}}
 
 {{ if and $.Values.grpc.enabled $.Values.grpc.public }}
-{{ if not (lookup "v1" "Service" "ambassador" "ambassador") }}
----
-apiVersion: getambassador.io/v2
-kind: Host
-metadata:
-  name: {{ $.Release.Name }}-domain{{ $domain_index }}-grpc
-  namespace: {{ $.Release.Namespace }}
-spec:
-  hostname: "{{ $.Release.Name }}.grpc.{{ $domain }}"
-  acmeProvider:
-    authority: none
-  requestPolicy:
-    insecure:
-      action: Route
-{{ end }} {{/* if not (lookup "v1" "Service" "ambassador" "ambassador") */}}
-
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping


### PR DESCRIPTION
I've removed all subdomains definition so all Mappings are now in the only Host — that even reduced amount of routes.
But for every mapping it checks the hostname, so it doesn't cause collisions.

I've also added the prefix route in addition to subdomain.

It's already applied to all review deployments and to one on staging — everything works including new prefix