### PR TITLE
DEVOPS-213 Add quotes to environment variables

### DIFF
--- a/charts/delphai-keda/Chart.yaml
+++ b/charts/delphai-keda/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: delphai-keda
 description: delphai service
 type: application
-version: 0.2.12
+version: 0.2.13

--- a/charts/delphai-keda/templates/deployment.yml
+++ b/charts/delphai-keda/templates/deployment.yml
@@ -78,7 +78,7 @@ spec:
               value: {{ .Values.delphaiEnvironment }}
             {{- range .Values.env }}
             - name: {{ .name }}
-              value: {{ .value }}
+              value: {{ .value | quote }}
             {{- end }}
             {{ if .Values.gpu }}
             - name: NVIDIA_VISIBLE_DEVICES


### PR DESCRIPTION
In cases where we want to set environment variables like `PYTORCH_NO_CUDA_MEMORY_CACHING=1`, the deployment fails whether the value is quoted or not in the values file. Skipping the quotes with `\` makes the deployment proceed but we don't get the expected env variable. Quoting the values in the template `value: {{ $value | quote }}` solves it.  I tested this also for env variables that are originally quoted in `values.yml` and it works fine for both. It would be useful for similar cases in the future.