### PR TITLE
DEVOPS-255 add GPU preference affinity

### DIFF
--- a/charts/delphai-keda/Chart.yaml
+++ b/charts/delphai-keda/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: delphai-keda
 description: delphai service
 type: application
-version: 0.2.17
+version: 0.2.18

--- a/charts/delphai-keda/templates/deployment.yml
+++ b/charts/delphai-keda/templates/deployment.yml
@@ -29,8 +29,8 @@ spec:
       nodeSelector:
         gpu: "true"
       {{ end }}
-      {{ if .Values.onePodMaxPerNodePerApp }}
       affinity:
+      {{ if .Values.onePodMaxPerNodePerApp }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -40,6 +40,17 @@ spec:
                     values:
                       - {{ .Release.Name }}
               topologyKey: kubernetes.io/hostname
+      {{ end }}
+      {{ if .Values.preferGpu }}
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: gpu
+                operator: In
+                values:
+                - "true"
       {{ end }}
       imagePullSecrets:
         - name: acr-credentials

--- a/charts/delphai-keda/values.yaml
+++ b/charts/delphai-keda/values.yaml
@@ -28,6 +28,7 @@ gpu: false
 mountPath: /app/data
 fileShares: []
 onePodMaxPerNodePerApp: false
+preferGpu: false
 resources:
   requests:
     memory: 300Mi


### PR DESCRIPTION
Adding `preferGpu` in case of apps that would prefer to use GPU nodes. Here the requirement is soft as it's just a preference - in case it's not possible to schedule on a GPU node, it will be done on another node type. 
`affinity: `  here is moved out of the `if` blocks, and in the case where `preferGpu` and `onePodMaxPerNodePerApp` are both `false`, affinity is then considered empty and isn't reflected in the actual deployment.
Changes have been tested on review for translation and GPU nodes are indeed being preferred.