### PR TITLE
DEVOPS-283 Allow OAuth proxy to use more CPU

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.2.0"
+version: "0.2.1"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -262,7 +262,7 @@ spec:
             timeoutSeconds: 10
 
           resources:
-            limits:
+            requests:
               cpu: "10m"
               memory: "30Mi"
         {{ end }} {{/* if $.Values.ingress.oAuth */}}

--- a/charts/delphai-keda/Chart.yaml
+++ b/charts/delphai-keda/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: delphai-keda
 description: delphai service
 type: application
-version: 0.2.21
+version: 0.2.22

--- a/charts/delphai-keda/templates/deployment.yml
+++ b/charts/delphai-keda/templates/deployment.yml
@@ -192,7 +192,7 @@ spec:
             timeoutSeconds: 10
 
           resources:
-            limits:
-              cpu: 10m
-              memory: 30Mi
+            requests:
+              cpu: "10m"
+              memory: "30Mi"
         {{ end }}


### PR DESCRIPTION
It turns out that AKS enforces CPU limit very strict
Lets relax the limit then