### PR TITLE
DEVOPS-311 Customize debug mode values

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.2.3"
+version: "0.2.4"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -123,10 +123,13 @@ spec:
 
           image: {{ required "`image` value is required" $.Values.image | quote }}
 
-          {{ if $.Values.debugMode.enabled }}
+          {{ if and $.Values.debugMode.enabled $.Values.debugMode.command }}
           command: {{ $.Values.debugMode.command | toYaml | nindent 10 }}
+          {{ end }} {{/* if and $.Values.debugMode.enabled $.Values.debugMode.command */}}
+
+          {{ if and $.Values.debugMode.enabled $.Values.debugMode.args }}
           args: {{ $.Values.debugMode.args | toYaml | nindent 10 }}
-          {{ end }} {{/* if $.Values.debugMode.enabled */}}
+          {{ end }} {{/* if and $.Values.debugMode.enabled $.Values.debugMode.args */}}
 
           resources: {{ toJson $.Values.resources }}
 


### PR DESCRIPTION
That allows to define
```yaml
debugMode:
  enabled: true
  command:
# or
  command: ""
# or
  command: ~
# or
  command: null
```
to NOT override the entrypoint in debug mode. Same for `args`

I've tested it, it works fine