### PR TITLE
DEVOPS-404 feat: add readiness probe

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.2.6"
+version: "0.2.7"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -211,20 +211,24 @@ spec:
             {{ end }} {{/* range ports */}}
 
           {{ if or (eq $.Values.readinessProbe.enabled nil) $.Values.readinessProbe.enabled }}
-          {{ $readinessProbePortName := $.Values.readinessProbe.portName }}
-          {{ if not (has $readinessProbePortName (list "" "http" "httpgateway")) }}
-          {{ fail "readinessProbe.portName must be one of ('', 'http', 'httpgateway')." }}
-          {{ end }} {{/* if not (has $readinessProbePortName (list "" "http" "httpgateway")) */}}
 
-          {{ if eq $readinessProbePortName "" }}
-          {{ if or (eq $.Values.ports.httpgateway.enabled nil) $.Values.ports.httpgateway.enabled }}
-          {{ $readinessProbePortName = "httpgateway" }}
-          {{ else if or (eq $.Values.ports.http.enabled nil) $.Values.ports.http.enabled }}
-          {{ $readinessProbePortName = "http" }}
+          {{/* readinessProbe.portName input validation/open port discovery */}}
+          {{ $readinessProbePortName := $.Values.readinessProbe.portName }}
+          {{ if eq $readinessProbePortName "oauthproxy" }}
+            {{ fail "readinessProbe.portName must not be 'oauthproxy'." }}
+          {{ else if eq $readinessProbePortName "" }}
+            {{ range $portName, $portConf := $.Values.ports }}
+            {{ if eq $portName "oauthproxy" }}
+              {{ continue }}
+            {{ end }} {{/* if eq $portName "oauthproxy" */}}
+            {{ if or (eq $portConf.enabled nil) $portConf.enabled }}
+              {{ $readinessProbePortName = $portName }}
+              {{ break }} {{/* range $portName, $portConf := $.Values.ports */}}
+            {{ end }} {{/* if or (eq $portConf.enabled nil) $portConf.enabled */}}
+            {{ end }} {{/* range $portName, $portConf := $.Values.ports */}}
+          {{ else if not (index $.Values.ports $readinessProbePortName).enabled }}
+            {{ fail "readinessProbe.portName must correspond to an enabled port." }}
           {{ end }} {{/* if */}}
-          {{ else if not (index $.Values.ports $readinessProbePortName).enabled}}
-          {{ fail "readinessProbe.portName must correspond to an enabled port." }}
-          {{ end }} {{/* if eq $readinessProbePortName "" */}}
 
           {{ if ne $readinessProbePortName "" }}
           readinessProbe:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -202,11 +202,41 @@ spec:
 
           ports:
             {{ range $portName, $portConf := $.Values.ports }}
+            {{ if ne $portName "oauthproxy" }}
             {{ if or (eq $portConf.enabled nil) $portConf.enabled }}
             - name: {{ $portName | quote }}
               containerPort: {{ $portConf.port }}
             {{ end }} {{/* if or (eq $portConf.enabled nil) $portConf.enabled */}}
+            {{ end }} {{/* if ne $portName "oauthproxy" */}}
             {{ end }} {{/* range ports */}}
+
+          {{ if or (eq $.Values.readinessProbe.enabled nil) $.Values.readinessProbe.enabled }}
+          {{ $readinessProbePortName := $.Values.readinessProbe.portName }}
+          {{ if eq $readinessProbePortName "" }}
+          {{ if $.Values.ports.httpgateway.enabled }}
+          {{ $readinessProbePortName = "httpgateway" }}
+          {{ else if $.Values.ports.http.enabled }}
+          {{ $readinessProbePortName = "http" }}
+          {{ else if $.Values.ports.grpc.enabled }}
+          {{ $readinessProbePortName = "grpc" }}
+          {{ end }} {{/* if $.Values.ports.httpgateway.enabled */}}
+          {{ end }} {{/* if eq $readinessProbePortName nil */}}
+
+          {{ if ne $readinessProbePortName "" }}
+          readinessProbe:
+            {{ if eq $readinessProbePortName "grpc" }}
+            grpc:
+            {{ else }}
+            tcpSocket:
+            {{ end }} {{/* if eq $readinessProbePortName "grpc" */}}
+              port: {{ (index $.Values.ports $readinessProbePortName).port }}
+            initialDelaySeconds: {{ $.Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ $.Values.readinessProbe.timeoutSeconds }}
+          {{ else }}
+          {{ fail "Cannot enable readinessProbe without open ports." }}
+          {{ end }} {{/* if ne $readinessProbePortName nil */}}
+          {{ end }} {{/* if or (eq $.Values.readinessProbe.enabled nil) $.Values.readinessProbe.enabled */}}
 
           {{ if or $schedulingRequireGPU $schedulingPreferGPU }}
           securityContext:
@@ -270,6 +300,11 @@ spec:
               port: "http"
               path: "/ping"
             timeoutSeconds: 10
+          
+          readinessProbe:
+            httpGet:
+              path: "/ping"
+              port: "http"
 
           resources:
             requests:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -212,30 +212,28 @@ spec:
 
           {{ if or (eq $.Values.readinessProbe.enabled nil) $.Values.readinessProbe.enabled }}
           {{ $readinessProbePortName := $.Values.readinessProbe.portName }}
+          {{ if not (has $readinessProbePortName (list "" "http" "httpgateway")) }}
+          {{ fail "readinessProbe.portName must be one of ('', 'http', 'httpgateway')." }}
+          {{ end }} {{/* if not (has $readinessProbePortName (list "" "http" "httpgateway")) */}}
+
           {{ if eq $readinessProbePortName "" }}
-          {{ if $.Values.ports.httpgateway.enabled }}
+          {{ if or (eq $.Values.ports.httpgateway.enabled nil) $.Values.ports.httpgateway.enabled }}
           {{ $readinessProbePortName = "httpgateway" }}
-          {{ else if $.Values.ports.http.enabled }}
+          {{ else if or (eq $.Values.ports.http.enabled nil) $.Values.ports.http.enabled }}
           {{ $readinessProbePortName = "http" }}
-          {{ else if $.Values.ports.grpc.enabled }}
-          {{ $readinessProbePortName = "grpc" }}
-          {{ end }} {{/* if $.Values.ports.httpgateway.enabled */}}
-          {{ end }} {{/* if eq $readinessProbePortName nil */}}
+          {{ end }} {{/* if */}}
+          {{ else if not (index $.Values.ports $readinessProbePortName).enabled}}
+          {{ fail "readinessProbe.portName must correspond to an enabled port." }}
+          {{ end }} {{/* if eq $readinessProbePortName "" */}}
 
           {{ if ne $readinessProbePortName "" }}
           readinessProbe:
-            {{ if eq $readinessProbePortName "grpc" }}
-            grpc:
-            {{ else }}
             tcpSocket:
-            {{ end }} {{/* if eq $readinessProbePortName "grpc" */}}
-              port: {{ (index $.Values.ports $readinessProbePortName).port }}
+              port: {{ $readinessProbePortName }}
             initialDelaySeconds: {{ $.Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ $.Values.readinessProbe.timeoutSeconds }}
-          {{ else }}
-          {{ fail "Cannot enable readinessProbe without open ports." }}
-          {{ end }} {{/* if ne $readinessProbePortName nil */}}
+          {{ end }} {{/* if ne $readinessProbePortName "" */}}
           {{ end }} {{/* if or (eq $.Values.readinessProbe.enabled nil) $.Values.readinessProbe.enabled */}}
 
           {{ if or $schedulingRequireGPU $schedulingPreferGPU }}
@@ -305,6 +303,7 @@ spec:
             httpGet:
               path: "/ping"
               port: "http"
+            timeoutSeconds: 5
 
           resources:
             requests:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -234,9 +234,7 @@ spec:
           readinessProbe:
             tcpSocket:
               port: {{ $readinessProbePortName }}
-            initialDelaySeconds: {{ $.Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ $.Values.readinessProbe.timeoutSeconds }}
+            {{- omit $.Values.readinessProbe "enabled" "portName" | toYaml | nindent 14 }}
           {{ end }} {{/* if ne $readinessProbePortName "" */}}
           {{ end }} {{/* if or (eq $.Values.readinessProbe.enabled nil) $.Values.readinessProbe.enabled */}}
 

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -234,7 +234,7 @@ spec:
           readinessProbe:
             tcpSocket:
               port: {{ $readinessProbePortName }}
-            {{- omit $.Values.readinessProbe "enabled" "portName" | toYaml | nindent 14 }}
+            {{- omit $.Values.readinessProbe "enabled" "portName" | toYaml | nindent 12 }}
           {{ end }} {{/* if ne $readinessProbePortName "" */}}
           {{ end }} {{/* if or (eq $.Values.readinessProbe.enabled nil) $.Values.readinessProbe.enabled */}}
 

--- a/charts/delphai-deployment/values.yaml
+++ b/charts/delphai-deployment/values.yaml
@@ -102,10 +102,10 @@ ports:
     port: 37070
 
 # Enable readiness probe
-# Will by default probe one of httpgateway/http/grpc ports, whichever is enabled in this order of precedence
+# Will by default probe one of httpgateway/http ports, whichever is enabled in this order of precedence
 readinessProbe:
   enabled: true
-  # Override probed port (name must be defined under `ports`)
+  # Override probed port (name must be one of httpgateway/http)
   portName: ""
 
   # Seconds to wait to start probe after main container initialization

--- a/charts/delphai-deployment/values.yaml
+++ b/charts/delphai-deployment/values.yaml
@@ -102,10 +102,10 @@ ports:
     port: 37070
 
 # Enable readiness probe
-# Will by default probe one of httpgateway/http ports, whichever is enabled in this order of precedence
+# Will by default probe one of the enabled ports, unless overriden in portName
 readinessProbe:
   enabled: true
-  # Override probed port (name must be one of httpgateway/http)
+  # Define probed port explicitly (must not be `oauthproxy`)
   portName: ""
 
   # Seconds to wait to start probe after main container initialization

--- a/charts/delphai-deployment/values.yaml
+++ b/charts/delphai-deployment/values.yaml
@@ -101,6 +101,20 @@ ports:
     enabled: false
     port: 37070
 
+# Enable readiness probe
+# Will by default probe one of httpgateway/http/grpc ports, whichever is enabled in this order of precedence
+readinessProbe:
+  enabled: true
+  # Override probed port (name must be defined under `ports`)
+  portName: ""
+
+  # Seconds to wait to start probe after main container initialization
+  initialDelaySeconds: 0
+  # Probe frequency
+  periodSeconds: 10
+  # Probe timeout (probe failed if response not received in time)
+  timeoutSeconds: 1
+
 # Enable Ingress
 ingress:
   enabled: false


### PR DESCRIPTION
Readiness probes tested with all ports and options.

Since gRPC is deprecated, before merging, we have to make sure that all gRPC services expose the `httpgateway` port as well and remove the relevant parts.