### PR TITLE
DEVOPS-416 refactor: disable default `mongo-credentials`

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.2.7"
+version: "0.2.8"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.2.8"
+version: "0.2.10"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -178,6 +178,17 @@ spec:
             {{ end }} {{/* if or (eq $secret.enabled nil) $secret.enabled */}}
             {{ end }} {{/* range $secret */}}
 
+            - name: "MONGO_CONNECTION_STRING"
+              valueFrom:
+                secretKeyRef:
+                  {{ if $.Values.mongo.enabled }} {{/* TODO add 'or (eq $.Values.mongo.enabled nil)' */}}
+                  name: {{ $.Values.mongo.connectionString.secretName | quote }}
+                  key: {{ $.Values.mongo.connectionString.secretKey | quote }}
+                  {{ else }} {{/* TODO remove */}}
+                  name: "mongo-credentials"
+                  key: "connection-string"
+                  {{ end }} {{/* if */}}
+
           volumeMounts:
             {{ range $volumeName, $volume := $.Values.volumes.commonFileShares }}
             {{ if or (eq $volume.enabled nil) $volume.enabled }}

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -149,17 +149,6 @@ spec:
               value: "compute,utility"
             {{ end }} {{/* if or $schedulingRequireGPU $schedulingPreferGPU */}}
 
-            - name: "MONGO_CONNECTION_STRING"
-              valueFrom:
-                secretKeyRef:
-                  {{ if $.Values.mongo.enabled }} {{/* TODO add 'or (eq $.Values.mongo.enabled nil)' */}}
-                  name: {{ $.Values.mongo.connectionString.secretName | quote }}
-                  key: {{ $.Values.mongo.connectionString.secretKey | quote }}
-                  {{ else }} {{/* TODO remove */}}
-                  name: "mongo-credentials"
-                  key: "connection-string"
-                  {{ end }} {{/* if */}}
-
             {{ range $name, $value := $.Values.env }}
             - name: {{ $name | quote }}
               value: {{ $value | quote }}
@@ -180,9 +169,6 @@ spec:
             {{ range $secretName, $secret := $.Values.secrets }}
             {{ if or (eq $secret.enabled nil) $secret.enabled }}
             {{ range $name, $key := $secret.env }}
-            {{ if eq $name "MONGO_CONNECTION_STRING" }}
-            {{ fail "MongoDB connection configuration has moved to the 'mongo' key." }}
-            {{ end }} {{/* if */}}
             - name: {{ $name | quote }}
               valueFrom:
                 secretKeyRef:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -149,6 +149,17 @@ spec:
               value: "compute,utility"
             {{ end }} {{/* if or $schedulingRequireGPU $schedulingPreferGPU */}}
 
+            - name: "MONGO_CONNECTION_STRING"
+              valueFrom:
+                secretKeyRef:
+                  {{ if $.Values.mongo.enabled }} {{/* TODO add 'or (eq $.Values.mongo.enabled nil)' */}}
+                  name: {{ $.Values.mongo.connectionString.secretName | quote }}
+                  key: {{ $.Values.mongo.connectionString.secretKey | quote }}
+                  {{ else }} {{/* TODO remove */}}
+                  name: "mongo-credentials"
+                  key: "connection-string"
+                  {{ end }} {{/* if */}}
+
             {{ range $name, $value := $.Values.env }}
             - name: {{ $name | quote }}
               value: {{ $value | quote }}
@@ -169,6 +180,9 @@ spec:
             {{ range $secretName, $secret := $.Values.secrets }}
             {{ if or (eq $secret.enabled nil) $secret.enabled }}
             {{ range $name, $key := $secret.env }}
+            {{ if eq $name "MONGO_CONNECTION_STRING" }}
+            {{ fail "MongoDB connection configuration has moved to the 'mongo' key." }}
+            {{ end }} {{/* if */}}
             - name: {{ $name | quote }}
               valueFrom:
                 secretKeyRef:
@@ -177,17 +191,6 @@ spec:
             {{ end }} {{/* range env */}}
             {{ end }} {{/* if or (eq $secret.enabled nil) $secret.enabled */}}
             {{ end }} {{/* range $secret */}}
-
-            - name: "MONGO_CONNECTION_STRING"
-              valueFrom:
-                secretKeyRef:
-                  {{ if $.Values.mongo.enabled }} {{/* TODO add 'or (eq $.Values.mongo.enabled nil)' */}}
-                  name: {{ $.Values.mongo.connectionString.secretName | quote }}
-                  key: {{ $.Values.mongo.connectionString.secretKey | quote }}
-                  {{ else }} {{/* TODO remove */}}
-                  name: "mongo-credentials"
-                  key: "connection-string"
-                  {{ end }} {{/* if */}}
 
           volumeMounts:
             {{ range $volumeName, $volume := $.Values.volumes.commonFileShares }}

--- a/charts/delphai-deployment/values.yaml
+++ b/charts/delphai-deployment/values.yaml
@@ -68,7 +68,6 @@ configMaps:
 #      PARAMETER: key-in-configmap
 
 # Import k8s Secrets
-# <secret-name>.env key may not be MONGO_CONNECTION_STRING
 secrets:
 #  secret-name:
 #    enabled: true                       # Optional
@@ -80,15 +79,10 @@ secrets:
 #    initEnv:                                  # Optional
 #      PARAMETER: key-in-configmap
 
-# Enable MongoDB access
-mongo:
-  enabled: false
-
-  connectionString:
-    # Secret name where connection string is stored
-    secretName: "mongodb-credentials"
-    # Secret key where connection string is stored
-    secretKey: "connection-string"
+  mongo-credentials:
+    enabled: false
+    env:
+      MONGO_CONNECTION_STRING: "connection-string"
 
 # Define ports exposed by the deployment (as k8s Service)
 ports:

--- a/charts/delphai-deployment/values.yaml
+++ b/charts/delphai-deployment/values.yaml
@@ -79,9 +79,15 @@ secrets:
 #    initEnv:                                  # Optional
 #      PARAMETER: key-in-configmap
 
-  mongo-credentials:
-    env:
-      MONGO_CONNECTION_STRING: "connection-string"
+# Enable MongoDB access
+mongo:
+  enabled: false
+
+  connectionString:
+    # Secret name where connection string is stored
+    secretName: "mongodb-credentials"
+    # Secret key where connection string is stored
+    secretKey: "connection-string"
 
 # Define ports exposed by the deployment (as k8s Service)
 ports:

--- a/charts/delphai-deployment/values.yaml
+++ b/charts/delphai-deployment/values.yaml
@@ -68,6 +68,7 @@ configMaps:
 #      PARAMETER: key-in-configmap
 
 # Import k8s Secrets
+# <secret-name>.env key may not be MONGO_CONNECTION_STRING
 secrets:
 #  secret-name:
 #    enabled: true                       # Optional


### PR DESCRIPTION
* temporarily move default secret envvar to template
