### PR TITLE
DEVOPS-414 enable `--pass-access-token` for `oauth2-proxy`

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.2.8"
+version: "0.2.9"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -253,6 +253,7 @@ spec:
             - "--email-domain=*"
             - "--provider=keycloak-oidc"
             - "--provider-display-name=Keycloak"
+            - "--pass-access-token"
             - "--skip-auth-route=^/favicon\\.ico$"
 
             {{ range $role := $.Values.ingress.oAuthRequireOneOfRoles }}


### PR DESCRIPTION
Confirmed that the JWT is provided by Keycloak by testing on review using an image of `ml-tools` with the `--set-xauthrequest` option enabled.