### PR TITLE
refactor: remove redundant nvidia envvars

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.2.11"
+version: "0.2.12"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -142,13 +142,6 @@ spec:
               value: "{{ $.Release.Name }}-redis-master.{{ $.Release.Namespace }}"
             {{ end }}
 
-            {{ if or $schedulingRequireGPU $schedulingPreferGPU }}
-            - name: NVIDIA_VISIBLE_DEVICES
-              value: "all"
-            - name: NVIDIA_DRIVER_CAPABILITIES
-              value: "compute,utility"
-            {{ end }} {{/* if or $schedulingRequireGPU $schedulingPreferGPU */}}
-
             {{ range $name, $value := $.Values.env }}
             - name: {{ $name | quote }}
               value: {{ $value | quote }}


### PR DESCRIPTION
Made redundant by the addition of k8s-device-plugin. Confirmed that GPU workloads work fine without them:

<img width="756" alt="image" src="https://github.com/delphai/helm-charts/assets/47861171/8337986b-4aab-48c8-a4a6-63b7fee02040">
