### PR TITLE
fix: add explicit GPU resource limit

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.2.12"
+version: "0.2.13"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -131,7 +131,14 @@ spec:
           args: {{ $.Values.debugMode.args | toYaml | nindent 10 }}
           {{ end }} {{/* if and $.Values.debugMode.enabled $.Values.debugMode.args */}}
 
-          resources: {{ toJson $.Values.resources }}
+          resources:
+            requests: {{ toJson $.Values.resources.requests }}
+            limits:
+              {{ if or $schedulingRequireGPU $schedulingPreferGPU }}
+              nvidia.com/gpu: 1
+              {{ end }} {{/* if or $schedulingRequireGPU $schedulingPreferGPU */}}
+              {{ $.Values.resources.limits | toYaml | nindent 14 }}
+
 
           env:
             - name: DELPHAI_ENVIRONMENT


### PR DESCRIPTION
Nvidia plugin already updated on both clusters - tested that these changes work on review by deploying a bunch of `coref-resolution` replicas under release `coref-multitest`, which I'll leave up until this PR is merged.

<img width="670" alt="image" src="https://github.com/delphai/helm-charts/assets/47861171/977c3e46-c61a-4161-814a-13578d5f85b6">

Two replicas ended up on the same node, which also allows us to confirm that time-slicing works fine (barring any changes related to memory such as those discussed this morning).

<img width="441" alt="image" src="https://github.com/delphai/helm-charts/assets/47861171/fedb7282-7993-46b1-b409-f7b59733300f">
