### PR TITLE
Expire OAuth cookie in 1 day

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.2.14"
+version: "0.2.15"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -262,6 +262,7 @@ spec:
             - "--provider-display-name=Keycloak"
             - "--pass-access-token"
             - "--skip-auth-route=^/favicon\\.ico$"
+            - "--cookie-expire=1d"
 
             {{ range $role := $.Values.ingress.oAuthRequireOneOfRoles }}
             - "--allowed-role={{ $role }}"


### PR DESCRIPTION
We had access token livespan 5 minutes in Keycloak but 7 days in oauth-proxy. So the token was expiring without refreshing.
Now I set both to 1 day to only ask users to relogin after that time