### PR TITLE
Revert "chore: redis as Deployment, not StatefulSet. (#69)"

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.2.18"
+version: "0.2.19"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -146,7 +146,7 @@ spec:
 
             {{ if $.Values.redis.enabled }}
             - name: REDIS_HOST
-              value: "{{ $.Release.Name }}-master.{{ $.Release.Namespace }}"
+              value: "{{ $.Release.Name }}-redis-master.{{ $.Release.Namespace }}"
             {{ end }}
 
             {{ range $name, $value := $.Values.env }}

--- a/charts/delphai-deployment/values.yaml
+++ b/charts/delphai-deployment/values.yaml
@@ -160,10 +160,6 @@ redis:
          cpu: 10m
          memory: 100Mi
 
-    ## @param master.kind Use either Deployment or StatefulSet (default)
-    ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
-    kind: Deployment
-
     ## @param master.tolerations Tolerations for Redis&reg; master pods assignment
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
     ##


### PR DESCRIPTION
This reverts commit 1303f34f01bdc00fb84f3bbec1cdde9bd53d1d69.

Something went wrong with the release of the page-scraper. We need to make sure that no-one picks up 0.2.18 while I investigate more.