### PR TITLE
Redis as a Deployment kind

### DIFF
--- a/charts/delphai-deployment/Chart.lock
+++ b/charts/delphai-deployment/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.3.7
-digest: sha256:584531300f137279e1ac8558f099dba75890204d3c4c4270655a2a92be2683e4
-generated: "2022-11-04T12:47:21.604379265+01:00"
+  version: 17.17.1
+digest: sha256:b706e54b00620679a74753c1566995e9f629da845cf885b21f28aa8cb5627607
+generated: "2023-11-29T08:18:02.741393289+01:00"

--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.2.19"
+version: "0.2.20"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/values.yaml
+++ b/charts/delphai-deployment/values.yaml
@@ -160,6 +160,10 @@ redis:
          cpu: 10m
          memory: 100Mi
 
+    ## @param master.kind Use either Deployment or StatefulSet (default)
+    ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+    kind: Deployment
+
     ## @param master.tolerations Tolerations for Redis&reg; master pods assignment
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
     ##


### PR DESCRIPTION
In this PR we change the redis workload kind from the default `StatefulSet` to a simpler `Deployment`.

During the deployment, new redis-master pods will be created, but the `[service]-redis-master` Service will stay the same, and the new `Endpoints` will be practically identical to the old ones - with the same labels, only with different timestamp metadata etc.

===

Tested on review using the page-scraper service `https://app.delphai.pink/service/page-scraper-deployment-kind/`

===
As a side-note, the `Chart.lock` gets updated to specify that we deploy redis based on Chart 17.17.1, not an older version. This is what actually is used in production.