### PR TITLE
feat: new optional env variable OIDC_BASE_URL.

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.4.3"
+version: "0.5.0"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -155,6 +155,9 @@ spec:
               value: "{{ $.Release.Name }}-redis-master.{{ $.Release.Namespace }}"
             {{ end }}
 
+            - name: OIDC_BASE_URL
+              value: "https://auth.{{ $.clusterValues.baseDomain }}/auth/realms/delphai"
+
             {{ range $name, $value := $.Values.env }}
             - name: {{ $name | quote }}
               value: {{ $value | quote }}


### PR DESCRIPTION
The env variable points at the correct auth server, e.g. our Keycloak.