### PR TITLE
feat: Keycloak OIDC is available as an internal k8s Service.

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.5.0"
+version: "0.5.1"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -156,7 +156,7 @@ spec:
             {{ end }}
 
             - name: OIDC_BASE_URL
-              value: "https://auth.{{ $.clusterValues.baseDomain }}/auth/realms/delphai"
+              value: "http://keycloak-http.keycloak.svc/auth/realms/delphai"
 
             {{ range $name, $value := $.Values.env }}
             - name: {{ $name | quote }}


### PR DESCRIPTION
Traffic inside the k8s cluster is faster and simpler than accessing a public IP.