### PR TITLE
fix: external DNS for Keycloak OIDC access.

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.5.1"
+version: "0.5.2"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/deployment.yaml
+++ b/charts/delphai-deployment/templates/deployment.yaml
@@ -156,7 +156,7 @@ spec:
             {{ end }}
 
             - name: OIDC_BASE_URL
-              value: "http://keycloak-http.keycloak.svc/auth/realms/delphai"
+              value: "https://auth.{{ $.clusterValues.baseDomain }}/auth/realms/delphai"
 
             {{ range $name, $value := $.Values.env }}
             - name: {{ $name | quote }}


### PR DESCRIPTION
This fixes authentication in Swagger GUI apps served by several backend services. Swagger GUI runs in the developer's browser, not in a k8s cluster.