### PR TITLE
CROS-1441 NOTES.txt documents public API

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.6.1"
+version: "0.6.2"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/NOTES.txt
+++ b/charts/delphai-deployment/templates/NOTES.txt
@@ -6,6 +6,13 @@
 {{- $urlPrefix := tpl $.Values.ingress.urlPrefix $ -}}
 This service exposes following endpoint(s):
  * HTTPS: https://{{ $subdomain | replace ".*" "" }}.{{ $.clusterValues.baseDomain }}{{ $urlPrefix | default "/" }}
+{{- if $.Values.ingress.publicApiPrefix }}
+{{- $branchPrefix := "" }}
+{{- if not (index $.Values.buildMetadata.labels "com.delphai.image.release") }}
+{{- $branchPrefix = print "/" $.Release.Name }}
+{{- end }} {{/* if not (index $.Values.buildMetadata.labels "com.delphai.image.release") */}}
+ * Public API: https://api.{{ $.clusterValues.baseDomain }}{{ $branchPrefix }}{{ $.Values.ingress.publicApiPrefix }}
+{{- end }} {{/* if $.Values.ingress.publicApiPrefix */}}
 {{- if $.Values.ingress.grpc }}
  * GRPC: {{ $.Release.Name }}.grpc.{{ $.clusterValues.baseDomain }}:80
 {{- end -}} {{- /* if $.Values.ingress.grpc */ -}}


### PR DESCRIPTION
This change is a small DevX quality of life improvement.

Sample usage:
```
Release "companies-tadek-test-deployment" has been upgraded. Happy Helming!
NAME: companies-tadek-test-deployment
LAST DEPLOYED: Thu Oct 31 11:25:30 2024
NAMESPACE: companies
STATUS: deployed
REVISION: 4
TEST SUITE: None
NOTES:
This service exposes following endpoint(s):
 * HTTPS: https://app.delphai.pink/service/companies-tadek-test-deployment/ 
 * Public API: https://api.delphai.pink/companies-tadek-test-deployment/v1/companies/
 * GRPC: companies-tadek-test-deployment.grpc.delphai.pink:80
```