### PR TITLE
feat: CORS configuration for public API

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.6.2"
+version: "0.6.3"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/mapping.yaml
+++ b/charts/delphai-deployment/templates/mapping.yaml
@@ -102,11 +102,7 @@ spec:
     - Accept
     - Authorization
     - Content-Type
-    - grpc-timeout
     - Origin
-    - X-GENERAL-TOKEN
-    - x-grpc-web
-    - X-Request-With
     max_age: "86400"
     methods: GET, PUT, POST, DELETE, HEAD, OPTIONS, PATCH
     origins: "https://docs.{{ $.clusterValues.baseDomain }}"

--- a/charts/delphai-deployment/templates/mapping.yaml
+++ b/charts/delphai-deployment/templates/mapping.yaml
@@ -96,6 +96,21 @@ spec:
   {{- fail "No HTTP ports found to publish as a public API" -}}
   {{ end }} {{/* if or (eq $.Values.ports.http.enabled nil) $.Values.ports.http.enabled */}}
 
+  cors:
+    credentials: true
+    headers:
+    - Accept
+    - Authorization
+    - Content-Type
+    - grpc-timeout
+    - Origin
+    - X-GENERAL-TOKEN
+    - x-grpc-web
+    - X-Request-With
+    max_age: "86400"
+    methods: GET, PUT, POST, DELETE, HEAD, OPTIONS, PATCH
+    origins: "https://docs.{{ $.clusterValues.baseDomain }}"
+
   timeout_ms: 60000
   idle_timeout_ms: 500000
 


### PR DESCRIPTION
This PR configures CORS for the public API endpoints. The work in this PR is based on modifications which Anton recently made in production Mappings.

It can be tested with a test deployment of `docs` that uses a test deployment of `companies` here: https://docs-tadek-test-deployment.delphai.pink/

For reference, the Azure API Management had:

```
        <cors>
            <allowed-origins>
                <origin>*</origin>
            </allowed-origins>
            <allowed-methods>
                <method>GET</method>
                <method>POST</method>
            </allowed-methods>
            <allowed-headers>
                <header>Origin</header>
                <header>Content-Type</header>
                <header>Accept</header>
                <header>Authorization</header>
            </allowed-headers>
        </cors>
```