### PR TITLE
feat: public API CORS allows Excel Add-In origin

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.6.4"
+version: "0.6.5"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/mapping.yaml
+++ b/charts/delphai-deployment/templates/mapping.yaml
@@ -107,7 +107,7 @@ spec:
     methods: GET, PUT, POST, DELETE, HEAD, OPTIONS, PATCH
     origins:
     - "https://docs.{{ $.clusterValues.baseDomain }}"
-    - "https://delphaiexceladdinreview.z6.web.core.windows.net"
+    - "https://delphaiexceladdinreview.z6.web.core.windows.net"     # https://portal.azure.com/#@delphai.dev/resource/subscriptions/6e9861b7-fa0e-4e09-84e8-51dbd5982a68/resourceGroups/excel-add-in/providers/Microsoft.Storage/storageAccounts/delphaiexceladdinreview/storagebrowser
   timeout_ms: 60000
   idle_timeout_ms: 500000
 

--- a/charts/delphai-deployment/templates/mapping.yaml
+++ b/charts/delphai-deployment/templates/mapping.yaml
@@ -103,14 +103,11 @@ spec:
     - Authorization
     - Content-Type
     - Origin
-    max_age: "86400"
+    max_age: "3600"
     methods: GET, PUT, POST, DELETE, HEAD, OPTIONS, PATCH
     origins:
     - "https://docs.{{ $.clusterValues.baseDomain }}"
-    - "https://intappinc.sharepoint.com"
-    - "https://onedrive.live.com"
-    - "https://madiscovergmbh.sharepoint.com"
-
+    - "https://delphaiexceladdinreview.z6.web.core.windows.net"
   timeout_ms: 60000
   idle_timeout_ms: 500000
 


### PR DESCRIPTION
The JavaScript code of the Add-In is hosted on a cross-site location https://delphaiexceladdinreview.z6.web.core.windows.net. In this change we whitelist that Origin.

We also lower the CORS Cache TTL to make future changes easier.