### PR TITLE
feat: ScaledObjects have HPA scaling behavior.

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.7.2"
+version: "0.7.3"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/scaled-object.yaml
+++ b/charts/delphai-deployment/templates/scaled-object.yaml
@@ -24,5 +24,28 @@ spec:
       value: {{ $.Values.autoscaling.rabbitmq.value | quote}}
   {{ end }} {{/* if $.Values.autoscaling.rabbitmq.enabled */}}
 
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+          - type: Percent
+            value: 10
+            periodSeconds: 15
+          - type: Pods
+            value: 10
+            periodSeconds: 15
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 200
+            periodSeconds: 15
+          - type: Pods
+            value: 10
+            periodSeconds: 15
+          selectPolicy: Max
+
 {{ end }} {{/* if index $.Values.buildMetadata.labels "com.delphai.image.release" */}}
 {{ end }} {{/* if $enabled */}}


### PR DESCRIPTION
In this PR we add custom scaling behaviors to Horizontal Pod Autoscalers which are controlled by KEDA's ScaledObjects. Scaling up will be more rapid than default. Scaling down will be gentler than default. This will make our queue-based workloads more even, with less of a need to scale up and down by hundreds of pods every short while.

Consider the `translation` service (`minReplicaCount: 1`, `maxReplicaCount: 500`): Full scale up from 1 to 500 will now take 6 decision periods, previously it was 9. Full scale down from 500 to 1 will now take 27 decision periods, previously it was 1.

Consider the `coref-resolution` service (`minReplicaCount: 3`, `maxReplicaCount: 320`): Full scale up from 3 to 320 will now take 5 decision periods, previously it was 8. Full scale down from 320 to 3 will now take 22 decision periods, previously it was 1.