### PR TITLE
chore: Redis has an image in delphai's ACR

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.9.0"
+version: "0.9.1"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/values.yaml
+++ b/charts/delphai-deployment/values.yaml
@@ -176,6 +176,10 @@ ingress:
 redis:
   enabled: false
 
+  image:
+    registry: delphaiwesteurope.azurecr.io
+    repository: redis
+
   architecture: standalone
 
   auth:


### PR DESCRIPTION
Upstream opensource provider Bitnami is changing their business conditions in the coming weeks so we'll copy their opensource images to our ACR for now.