### PR TITLE
DDEVOPS-719: suspended CronJobs for dev branch releases.

### DIFF
--- a/charts/delphai-deployment/Chart.yaml
+++ b/charts/delphai-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "delphai-deployment"
-version: "0.10.0"
+version: "0.10.1"
 description: "Standard service deployment"
 type: "application"
 dependencies:

--- a/charts/delphai-deployment/templates/cron-job.yaml
+++ b/charts/delphai-deployment/templates/cron-job.yaml
@@ -1,5 +1,3 @@
-{{ if index $.Values.buildMetadata.labels "com.delphai.image.release" }}
-
 {{ range $cronjobName, $cronjob := $.Values.cronjobs }}
 ---
 apiVersion: batch/v1
@@ -10,6 +8,7 @@ metadata:
 spec:
   schedule: {{ $cronjob.schedule | quote }}
   concurrencyPolicy: Replace
+  suspend: {{ index $.Values.buildMetadata.labels "com.delphai.image.release" | not }}
   jobTemplate:
     spec:
       template:
@@ -64,5 +63,3 @@ spec:
             {{ end }} {{/* if $cronjob.args */}}
 
 {{ end }} {{/* range cronjobs */}}
-
-{{ end }} {{/* if index $.Values.buildMetadata.labels "com.delphai.image.release" */}}


### PR DESCRIPTION
Dev branch releases will now create suspended CronJobs, that can be manually triggered for testing purposes.